### PR TITLE
Grafana UI: W/m2 should still support SI prefixes

### DIFF
--- a/packages/grafana-data/src/valueFormats/categories.ts
+++ b/packages/grafana-data/src/valueFormats/categories.ts
@@ -225,7 +225,7 @@ export const getCategories = (): ValueFormatCategory[] => [
       { name: 'Megawatt (MW)', id: 'megwatt', fn: SIPrefix('W', 2) },
       { name: 'Gigawatt (GW)', id: 'gwatt', fn: SIPrefix('W', 3) },
       { name: 'Milliwatt (mW)', id: 'mwatt', fn: SIPrefix('W', -1) },
-      { name: 'Watt per square meter (W/m²)', id: 'Wm2', fn: toFixedUnit('W/m²') },
+      { name: 'Watt per square meter (W/m²)', id: 'Wm2', fn: SIPrefix('W/m²') },
       { name: 'Volt-Ampere (VA)', id: 'voltamp', fn: SIPrefix('VA') },
       { name: 'Kilovolt-Ampere (kVA)', id: 'kvoltamp', fn: SIPrefix('VA', 1) },
       { name: 'Volt-Ampere reactive (VAr)', id: 'voltampreact', fn: SIPrefix('VAr') },


### PR DESCRIPTION
Incredibly simple change, Watts is a measure of Energy and has SI prefixes, so if it's measured per square meter, it should still support SI prefixes.
